### PR TITLE
Correção no condicional da função nextTurn

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -79,7 +79,7 @@ function nextTurn(){
     }
     if(currentTurn <= totalTurns){
         if(isBreakTime){
-            if(currentTurn < totalTime){
+            if(currentTurn < totalTurns){
                 totalTime = breakTime;
             }else{
                 totalTime = longBreakTime;


### PR DESCRIPTION
Devido ao autocomplete do VS Code, não foi definida a variável correção no condicional da função nextTurn.